### PR TITLE
Increase limits on ROOT formula length

### DIFF
--- a/handoff_response/src/gen/MyAnalysis.cxx
+++ b/handoff_response/src/gen/MyAnalysis.cxx
@@ -23,7 +23,7 @@ MyAnalysis::MyAnalysis(embed_python::Module& py)
    // get file information from input description 
    // first, file list
    
-   //TFormula::SetMaxima(2000,2000,2000);
+   TFormula::SetMaxima(2000,2000,2000);
 
    py.getList("Data.files", m_files);
    std::cout << "Reading from " << m_files.size() 

--- a/handoff_response/src/gen/MyAnalysis.cxx
+++ b/handoff_response/src/gen/MyAnalysis.cxx
@@ -9,6 +9,7 @@
 #include "TCanvas.h"
 #include "TPaveLabel.h"
 #include "TEventList.h"
+#include "TFormula.h"
 #include <cmath>
 #include <sstream>
 #include <iostream>
@@ -22,6 +23,8 @@ MyAnalysis::MyAnalysis(embed_python::Module& py)
    // get file information from input description 
    // first, file list
    
+   //TFormula::SetMaxima(2000,2000,2000);
+
    py.getList("Data.files", m_files);
    std::cout << "Reading from " << m_files.size() 
              << " filelists" << std::endl;


### PR DESCRIPTION
This PR increases the ROOT limit on formula length in the IRF generation utilities.  The default limits were resulting in failures when attempting to resolve long cut expressions such as those used in the P8R3 selections.
