### PR TITLE
Lk 84

### DIFF
--- a/latResponse/src/PsfIntegralCache.cxx
+++ b/latResponse/src/PsfIntegralCache.cxx
@@ -135,7 +135,6 @@ psfIntegral(double psi, double sigma, double gamma) const {
    double err(1e-3);
    int ierr(0);
 
-//   std::err << set_precision(10) << mum << ", " << roi_radius << ", " << psi << std::endl;
    double firstIntegral(0);
    if ( mum < 0.9999 ) {
       PsfIntegrand1 psfIntegrand1(sigma, gamma);

--- a/latResponse/src/PsfIntegralCache.cxx
+++ b/latResponse/src/PsfIntegralCache.cxx
@@ -135,8 +135,9 @@ psfIntegral(double psi, double sigma, double gamma) const {
    double err(1e-3);
    int ierr(0);
 
+//   std::err << set_precision(10) << mum << ", " << roi_radius << ", " << psi << std::endl;
    double firstIntegral(0);
-   if ( mum < 0.99 ) {
+   if ( mum < 0.9999 ) {
       PsfIntegrand1 psfIntegrand1(sigma, gamma);
       firstIntegral = 
          st_facilities::GaussianQuadrature::dgaus8(psfIntegrand1, mum,

--- a/latResponse/src/PsfIntegralCache.cxx
+++ b/latResponse/src/PsfIntegralCache.cxx
@@ -136,7 +136,8 @@ psfIntegral(double psi, double sigma, double gamma) const {
    int ierr(0);
 
    double firstIntegral(0);
-   if ( mum < 0.9999 ) {
+//   if ( psi < roi_radius ) {
+   if ( (mum < 0.999999999) && (psi < roi_radius)) {
       PsfIntegrand1 psfIntegrand1(sigma, gamma);
       firstIntegral = 
          st_facilities::GaussianQuadrature::dgaus8(psfIntegrand1, mum,


### PR DESCRIPTION
Increased the tolerance value.  The previous value had a limit of 8.1 degrees from the ROI boundary while the new one reduces that to 0.81 degrees.  This allows both the test from Likelihood issue 84 (https://github.com/fermi-lat/Likelihood/issues/84) and Likelihood issue 70 (https://github.com/fermi-lat/Likelihood/issues/70) to pass.